### PR TITLE
chore: Set MSRV to 1.85 and add MSRV check CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,12 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-features -- -D warnings
+
+  msrv:
+    name: MSRV (1.85)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.85
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.85
       - uses: Swatinem/rust-cache@v2
-      - run: cargo check --all-features
+      - run: cargo check --locked --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "http-relay"
 description = "A Rust implementation of _some_ of [Http relay spec](https://httprelay.io/)."
 version = "0.7.0"
 edition = "2021"
+rust-version = "1.85"
 authors = ["SeverinAlexB"]
 license = "MIT"
 homepage = "https://github.com/pubky/http-relay"


### PR DESCRIPTION
## Summary
- Set `rust-version = "1.85"` in `Cargo.toml`. Version 1.85 compiles the crate with `--all-features`.
- Add an `msrv` job to `.github/workflows/ci.yml` pinned to Rust 1.85 running `cargo check --all-features`, following Pubky org standard CI pattern.